### PR TITLE
Add support for podAnnotations on deployments

### DIFF
--- a/charts/kubetemplates/Chart.yaml
+++ b/charts/kubetemplates/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: kubetemplates
-version: 1.19.0-beta.6
+version: 1.19.0-beta.7

--- a/charts/kubetemplates/templates/_helpers.tpl
+++ b/charts/kubetemplates/templates/_helpers.tpl
@@ -637,6 +637,10 @@ spec:
 {{- if $value.metadata.labels }}
 {{- toYaml $value.metadata.labels | nindent 8 }}
 {{- end }}
+{{- if $value.podAnnotations }}
+      annotations:
+{{- toYaml $value.podAnnotations | nindent 8 }}
+{{- end }}
     spec:
 {{- if $value.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ $value.terminationGracePeriodSeconds }}

--- a/charts/test/sample-app/values.yaml
+++ b/charts/test/sample-app/values.yaml
@@ -70,6 +70,9 @@ deployments:
       annotations:
         prefix.svc.com/annotation1: 'true'
         prefix.svc.com/annotation2: 'false'
+    podAnnotations:
+      prefix.svc.com/annotation3: 'true'
+      prefix.svc.com/annotation4: 'false'
     replicaCount: 3
     deploymentStrategy:
       type: RollingUpdate


### PR DESCRIPTION
Add podAnnotations on deployment templates to allow deployments to propagate annotations to pods.
1.19.0-beta.7

Testing:

```bash
╰─>$ echo '{{- template "kubernetes.apps.deployment" . }}' > templates/test.yml
╰─>$ cat ~/example/values.yaml | yq '.deployments.*.podAnnotations'
exampleAnnotation: value
annotation2: value2
╰─>$ helm template . -f ~/example/values.yaml | yq 'select(.kind == "Deployment") | .spec.template.metadata.annotations'
annotation2: value2
exampleAnnotation: value
```