### PR TITLE
update cronjob api-version

### DIFF
--- a/charts/kubetemplates/Chart.yaml
+++ b/charts/kubetemplates/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: kubetemplates
-version: 1.19.0-beta.10
+version: 1.19.0-beta.11

--- a/charts/kubetemplates/Chart.yaml
+++ b/charts/kubetemplates/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: kubetemplates
-version: 1.19.0-beta.11
+version: 1.25.0

--- a/charts/kubetemplates/templates/_helpers.tpl
+++ b/charts/kubetemplates/templates/_helpers.tpl
@@ -533,7 +533,7 @@ spec:
 {{- define "kubernetes.batch.cronjob" -}}
 {{- range $key, $value := .Values.cronjobs }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ default $.Chart.Name $value.metadata.name | trunc 63 | trimSuffix "-" }}


### PR DESCRIPTION
API version `v1/beta1` for cronjob is deprecated and removed from Kubernetes version 1.25. This needs to be updated to `v1`.